### PR TITLE
Add an interactive setup wizard that cleans the repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:next": "turbo dev --filter=next",
     "dev:solid": "turbo dev --filter=solid",
     "dev:astro": "turbo dev --filter=astro",
+    "setup": "node scripts/setup/index.mjs",
     "scaffold": "node scripts/setup/index.mjs",
     "web": "turbo dev --filter=web",
     "test": "turbo run test",

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -1,27 +1,27 @@
 # Starter setup wizard
 
-Interactive script to strip this multi-stack starter down to just the pieces you
+Interactive script to strip this multi-stack starter down to the pieces you
 want. Run it once, right after cloning.
 
 ```bash
-node scripts/setup/index.mjs        # or: pnpm scaffold
-node scripts/setup/index.mjs --dry-run   # preview only, change nothing
-node scripts/setup/index.mjs --yes       # take all defaults, no prompts
+pnpm setup                      # or: pnpm scaffold
+pnpm setup --dry-run            # preview only, change nothing
+pnpm setup --yes                # take all defaults, no prompts
 ```
+
+On a TTY it uses **arrow keys** to move, **space** to toggle extras, and
+**enter** to confirm. Piped input falls back to numbered choices and y/n.
 
 It runs with **zero dependencies** so it works before `pnpm install`.
 
 ## What it asks
 
-| Question  | Choices                                  | Removes if not chosen                                        |
-| --------- | ---------------------------------------- | ----------------------------------------------------------- |
-| Framework | SolidStart / Next.js / Astro             | the other apps (`apps/solid`, `apps/next`, `apps/astro`; `packages/router` is Solid-only) |
-| WebGL     | three.js / OGL / none                    | `packages/three`, `packages/ogl`, `packages/gl-context`     |
-| Sanity    | yes / no                                 | `apps/cms`, `packages/sanity`, `scripts/sanity-yaml`, `scripts/sync-sanity` |
-| SEO       | yes / no (Solid + Sanity only)           | `packages/seo`                                              |
-| Shopify   | yes / no (Solid only)                    | `packages/shopify`                                         |
-| Optimise  | yes / no                                 | `scripts/optimise`                                         |
-| Placeholders | yes / no                              | empty stub dirs (`packages/animation`, `packages/types`, `packages/ui`) |
+| Question | Choices | Removes if not chosen |
+| --- | --- | --- |
+| Framework | SolidStart / Next.js / Astro | the other apps (`packages/router` is Solid-only) |
+| CMS | Sanity / None | `apps/cms`, `packages/sanity`, sync scripts, content routes, slices, preview/robots APIs; home pages become static |
+| WebGL | three.js / none (OGL if `packages/ogl` exists) | `packages/three`, `packages/gl-context`, webgl routes, canvas wiring, `clientRectGl` |
+| Extras | SEO (Solid + Sanity), Shopify (Solid), image/font optimise | matching packages, `/_/shop`, `@local/seo` usage, `scripts/optimise` |
 
 `packages/config`, `packages/tailwind`, and `packages/modules` are core and always kept.
 
@@ -43,15 +43,11 @@ work in framework code.
 
 ## What it does
 
-1. Deletes every directory you didn't select.
-2. Prunes `workspace:*` deps that point at removed packages from the remaining
-   `package.json` files.
-3. Removes framework-specific scripts from the root `package.json`.
-4. Writes your answers to `.starter.json`.
-5. Offers to run `pnpm install` to refresh the lockfile.
+1. Deletes unused apps, packages, and feature files (routes, slices, shop, canvas).
+2. Rewrites kept source so removed packages are not imported (nav links, home pages, canvas, SEO tags).
+3. Prunes `workspace:*` deps and leftover npm deps (`three`, …) from remaining manifests.
+4. Removes framework-specific scripts from the root `package.json`.
+5. Writes your answers to `.starter.json`.
+6. Offers to run `pnpm install` to refresh the lockfile.
 
-## What it does NOT do
-
-It does **not** rewrite your source code. If a file you keep still imports a
-package you removed, the wizard prints it as a warning so you can fix the import
-by hand. Always run inside a clean git tree so you can `git checkout` to undo.
+Always run inside a clean git tree so you can `git checkout` to undo.

--- a/scripts/setup/apply.mjs
+++ b/scripts/setup/apply.mjs
@@ -202,11 +202,43 @@ function identUsed(src, name) {
 }
 
 export function removeNavLink(src, href) {
-	const re = new RegExp(
-		`\\{\\s*(?:to|href):\\s*["']${escapeRe(href)}["']\\s*,\\s*text:\\s*["'][^"']*["']\\s*\\},?\\s*`,
-		"g",
-	);
-	return src.replace(re, "").replace(/,(\s*\])/g, "$1");
+	const needle = new RegExp(`(?:to|href):\\s*["']${escapeRe(href)}["']`);
+	let out = src;
+	while (true) {
+		const m = needle.exec(out);
+		if (!m) break;
+		let start = m.index;
+		while (start > 0 && out[start] !== "{") start -= 1;
+		if (out[start] !== "{") break;
+		let from = start;
+		while (from > 0 && /[ \t]/.test(out[from - 1])) from -= 1;
+		if (out[from - 1] === "\n") from -= 1;
+
+		let i = start;
+		let depth = 0;
+		while (i < out.length) {
+			const ch = out[i];
+			if (ch === '"' || ch === "'" || ch === "`") {
+				i = skipString(out, i);
+				continue;
+			}
+			if (ch === "{") {
+				depth += 1;
+				i += 1;
+				continue;
+			}
+			if (ch === "}") {
+				depth -= 1;
+				i += 1;
+				if (depth === 0) break;
+				continue;
+			}
+			i += 1;
+		}
+		if (out[i] === ",") i += 1;
+		out = out.slice(0, from) + out.slice(i);
+	}
+	return out;
 }
 
 export function emptyTranspilePackages(src) {
@@ -217,6 +249,17 @@ export function removeLineIncludes(src, needles) {
 	const lines = src.split("\n");
 	const kept = lines.filter((line) => !needles.some((needle) => line.includes(needle)));
 	return kept.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+export function removeObjectKey(src, key) {
+	return removeObjectProp(src, key);
+}
+
+export function stripThreeConfig(src) {
+	let out = src.replace(/\n\t\/\/ `three`[\s\S]*?(?=\n\tsolid:)/, "");
+	out = removeObjectProp(out, "solid");
+	out = removeObjectProp(out, "optimizeDeps");
+	return out;
 }
 
 export function stripShopifyConfig(src) {
@@ -231,6 +274,7 @@ export function stripShopifyConfig(src) {
 
 function removeObjectProp(src, key) {
 	const patterns = [`"${key}":`, `'${key}':`];
+	if (/^[A-Za-z_$][\w$]*$/.test(key)) patterns.push(`${key}:`);
 	let out = src;
 	for (const token of patterns) {
 		let idx = out.indexOf(token);
@@ -282,8 +326,30 @@ function applyPatches(src, patches) {
 		else if (patch.type === "sweep-imports") out = sweepUnusedImports(out);
 		else if (patch.type === "empty-transpile-packages") out = emptyTranspilePackages(out);
 		else if (patch.type === "remove-line-includes") out = removeLineIncludes(out, patch.needles);
+		else if (patch.type === "strip-three-config") out = stripThreeConfig(out);
+		else if (patch.type === "remove-object-key") out = removeObjectKey(out, patch.key);
 		else if (patch.type === "strip-shopify-config") out = stripShopifyConfig(out);
 		else warn(`Unknown patch type: ${patch.type}`);
+	}
+	return out.replace(/\n{3,}/g, "\n\n");
+}
+
+function mergePatchOps(ops) {
+	const patchesByPath = new Map();
+	const out = [];
+	for (const op of ops) {
+		if (op.type !== "patch-file") {
+			out.push(op);
+			continue;
+		}
+		const existing = patchesByPath.get(op.path);
+		if (existing) {
+			existing.patches.push(...op.patches);
+		} else {
+			const merged = { ...op, patches: [...op.patches] };
+			patchesByPath.set(op.path, merged);
+			out.push(merged);
+		}
 	}
 	return out;
 }
@@ -448,15 +514,16 @@ export function scanDanglingImports(root, keepDirs, removedNames) {
  */
 export function applyPlan(root, plan, opts = {}) {
 	const dryRun = Boolean(opts.dryRun);
+	const ops = mergePatchOps(plan.ops);
 	const dirToName = scanWorkspace(root);
 	const removedNames = new Set();
-	for (const op of plan.ops) {
+	for (const op of ops) {
 		if (op.type === "delete" && dirToName.has(op.path)) {
 			removedNames.add(dirToName.get(op.path));
 		}
 	}
 
-	for (const op of plan.ops) {
+	for (const op of ops) {
 		if (op.type === "delete") {
 			if (!existsSync(join(root, op.path))) continue;
 			if (!dryRun) rmSync(join(root, op.path), { recursive: true, force: true });

--- a/scripts/setup/apply.mjs
+++ b/scripts/setup/apply.mjs
@@ -1,0 +1,503 @@
+// @ts-check
+/**
+ * Apply a cleanup plan from model.mjs. Zero deps; safe to run before install.
+ */
+
+import { existsSync, readFileSync, writeFileSync, rmSync, readdirSync, statSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { ok, warn } from "./prompts.mjs";
+
+const DEP_FIELDS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+
+export function readJson(path) {
+	const raw = readFileSync(path, "utf8");
+	const indentMatch = raw.match(/^[ \t]*(\t|  +)/m);
+	const indent = indentMatch ? indentMatch[1] : "  ";
+	return { data: JSON.parse(raw), indent, trailingNewline: raw.endsWith("\n") };
+}
+
+export function writeJson(path, data, indent, trailingNewline) {
+	let out = JSON.stringify(data, null, indent);
+	if (trailingNewline) out += "\n";
+	writeFileSync(path, out);
+}
+
+function escapeRe(s) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function skipString(src, i) {
+	const q = src[i];
+	i += 1;
+	while (i < src.length) {
+		if (src[i] === "\\") {
+			i += 2;
+			continue;
+		}
+		if (src[i] === q) return i + 1;
+		i += 1;
+	}
+	return i;
+}
+
+/**
+ * Remove `const Name = ...;` including multiline calls.
+ * @param {string} src
+ * @param {string} name
+ */
+export function removeConstDecl(src, name) {
+	const re = new RegExp(`(?:export\\s+)?const\\s+${escapeRe(name)}\\s*=`);
+	const m = re.exec(src);
+	if (!m) return src;
+	let from = m.index;
+	while (from > 0 && (src[from - 1] === " " || src[from - 1] === "\t")) from -= 1;
+	if (src[from - 1] === "\n") from -= 1;
+
+	let i = m.index + m[0].length;
+	let depth = 0;
+	while (i < src.length) {
+		const ch = src[i];
+		if (ch === '"' || ch === "'" || ch === "`") {
+			i = skipString(src, i);
+			continue;
+		}
+		if (ch === "(" || ch === "{" || ch === "[") {
+			depth += 1;
+			i += 1;
+			continue;
+		}
+		if (ch === ")" || ch === "}" || ch === "]") {
+			depth -= 1;
+			i += 1;
+			continue;
+		}
+		if (ch === ";" && depth === 0) {
+			i += 1;
+			break;
+		}
+		i += 1;
+	}
+	return src.slice(0, from) + src.slice(i);
+}
+
+/**
+ * Remove every `<Tag ... />` or `<Tag>...</Tag>`, respecting `{...}` in props.
+ * @param {string} src
+ * @param {string} tag
+ */
+export function removeJsxTag(src, tag) {
+	let out = src;
+	const startRe = new RegExp(`\\s*<${escapeRe(tag)}(?=[\\s>/])`);
+	while (true) {
+		const m = startRe.exec(out);
+		if (!m) break;
+		const start = m.index;
+		const tagStart = out.indexOf(`<${tag}`, start);
+		let i = tagStart;
+		let depth = 0;
+		let end = -1;
+		while (i < out.length) {
+			const ch = out[i];
+			if (ch === '"' || ch === "'" || ch === "`") {
+				i = skipString(out, i);
+				continue;
+			}
+			if (ch === "{") {
+				depth += 1;
+				i += 1;
+				continue;
+			}
+			if (ch === "}") {
+				depth -= 1;
+				i += 1;
+				continue;
+			}
+			if (depth === 0 && out.startsWith("/>", i)) {
+				end = i + 2;
+				break;
+			}
+			if (depth === 0 && ch === ">") {
+				const close = out.indexOf(`</${tag}>`, i);
+				end = close >= 0 ? close + `</${tag}>`.length : i + 1;
+				break;
+			}
+			i += 1;
+		}
+		if (end < 0) break;
+		out = out.slice(0, start) + out.slice(end);
+	}
+	return out;
+}
+
+export function removeRobotsLink(src) {
+	return src.replace(/\n\s*<Link\s+rel="robots"[\s\S]*?\/>/, "");
+}
+
+/**
+ * Drop imported bindings that no longer appear in the file.
+ * @param {string} src
+ */
+export function sweepUnusedImports(src) {
+	const importRe =
+		/^import\s+(?:type\s+)?(?:(\w+)(?:\s*,\s*)?)?(?:\*\s+as\s+(\w+))?(?:\{([^}]*)\})?\s+from\s+['"][^'"]+['"];?[ \t]*\n?/gm;
+
+	/** @type {{ start: number, end: number, text: string, defaults: string[], names: { raw: string, local: string }[], star: string | null, from: string }[]} */
+	const blocks = [];
+	let m;
+	const fromRe = /from\s+['"]([^'"]+)['"]/;
+	while ((m = importRe.exec(src))) {
+		const text = m[0];
+		if (text.includes("(")) continue;
+		const from = fromRe.exec(text)?.[1] ?? "";
+		const names = (m[3] ?? "")
+			.split(",")
+			.map((part) => part.trim())
+			.filter(Boolean)
+			.map((raw) => {
+				const cleaned = raw.replace(/^type\s+/, "");
+				const [left, right] = cleaned.split(/\s+as\s+/);
+				return { raw, local: (right ?? left).trim() };
+			});
+		blocks.push({
+			start: m.index,
+			end: m.index + text.length,
+			text,
+			defaults: m[1] ? [m[1]] : [],
+			names,
+			star: m[2] ?? null,
+			from,
+		});
+	}
+
+	let out = src;
+	for (const block of [...blocks].reverse()) {
+		const rest = out.slice(0, block.start) + out.slice(block.end);
+		const keepDefault = block.defaults.filter((name) => identUsed(rest, name));
+		const keepStar = block.star && identUsed(rest, block.star) ? block.star : null;
+		const keepNames = block.names.filter((item) => identUsed(rest, item.local));
+
+		if (!keepDefault.length && !keepStar && !keepNames.length) {
+			out = out.slice(0, block.start) + out.slice(block.end);
+			continue;
+		}
+
+		const typeOnly = block.text.startsWith("import type");
+		let next = typeOnly ? "import type " : "import ";
+		if (keepDefault.length) next += keepDefault[0];
+		if (keepStar) next += `${keepDefault.length ? ", " : ""}* as ${keepStar}`;
+		if (keepNames.length) {
+			if (keepDefault.length || keepStar) next += ", ";
+			next += `{ ${keepNames.map((item) => item.raw).join(", ")} }`;
+		}
+		next += ` from "${block.from}";\n`;
+		out = out.slice(0, block.start) + next + out.slice(block.end);
+	}
+	return out.replace(/\n{3,}/g, "\n\n");
+}
+
+function identUsed(src, name) {
+	if (!name) return false;
+	const re = new RegExp(`\\b${escapeRe(name)}\\b`);
+	return re.test(src);
+}
+
+export function removeNavLink(src, href) {
+	const re = new RegExp(
+		`\\{\\s*(?:to|href):\\s*["']${escapeRe(href)}["']\\s*,\\s*text:\\s*["'][^"']*["']\\s*\\},?\\s*`,
+		"g",
+	);
+	return src.replace(re, "").replace(/,(\s*\])/g, "$1");
+}
+
+export function emptyTranspilePackages(src) {
+	return src.replace(/transpilePackages:\s*\[[^\]]*\]/, "transpilePackages: []");
+}
+
+export function removeLineIncludes(src, needles) {
+	const lines = src.split("\n");
+	const kept = lines.filter((line) => !needles.some((needle) => line.includes(needle)));
+	return kept.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+export function stripShopifyConfig(src) {
+	let out = src;
+	out = out.replace(/\n\s*ignore:\s*\[[^\]]*["']\/_\/shop[^]*?\],?/, "");
+	out = removeObjectProp(out, "/_/shop");
+	out = removeObjectProp(out, "/_/shop/**");
+	out = removeObjectProp(out, "/api/shopify/revalidate");
+	out = out.replace(/\n\s*routeRules:\s*\{\s*\},?/, "");
+	return out;
+}
+
+function removeObjectProp(src, key) {
+	const patterns = [`"${key}":`, `'${key}':`];
+	let out = src;
+	for (const token of patterns) {
+		let idx = out.indexOf(token);
+		while (idx >= 0) {
+			let start = idx;
+			while (start > 0 && /[ \t]/.test(out[start - 1])) start -= 1;
+			if (out[start - 1] === "\n") start -= 1;
+
+			let i = idx + token.length;
+			while (i < out.length && /\s/.test(out[i])) i += 1;
+			if (out[i] !== "{") {
+				idx = out.indexOf(token, idx + token.length);
+				continue;
+			}
+			let depth = 0;
+			while (i < out.length) {
+				const ch = out[i];
+				if (ch === '"' || ch === "'" || ch === "`") {
+					i = skipString(out, i);
+					continue;
+				}
+				if (ch === "{") {
+					depth += 1;
+					i += 1;
+					continue;
+				}
+				if (ch === "}") {
+					depth -= 1;
+					i += 1;
+					if (depth === 0) break;
+					continue;
+				}
+				i += 1;
+			}
+			if (out[i] === ",") i += 1;
+			out = out.slice(0, start) + out.slice(i);
+			idx = out.indexOf(token);
+		}
+	}
+	return out;
+}
+
+function applyPatches(src, patches) {
+	let out = src;
+	for (const patch of patches) {
+		if (patch.type === "remove-const") out = removeConstDecl(out, patch.name);
+		else if (patch.type === "remove-jsx") out = removeJsxTag(out, patch.tag);
+		else if (patch.type === "remove-robots-link") out = removeRobotsLink(out);
+		else if (patch.type === "sweep-imports") out = sweepUnusedImports(out);
+		else if (patch.type === "empty-transpile-packages") out = emptyTranspilePackages(out);
+		else if (patch.type === "remove-line-includes") out = removeLineIncludes(out, patch.needles);
+		else if (patch.type === "strip-shopify-config") out = stripShopifyConfig(out);
+		else warn(`Unknown patch type: ${patch.type}`);
+	}
+	return out;
+}
+
+function scanWorkspace(root) {
+	const dirToName = new Map();
+	for (const group of ["apps", "packages", "scripts"]) {
+		const groupDir = join(root, group);
+		if (!existsSync(groupDir)) continue;
+		for (const entry of readdirSync(groupDir)) {
+			const rel = `${group}/${entry}`;
+			const pkgPath = join(root, rel, "package.json");
+			if (!existsSync(pkgPath)) continue;
+			try {
+				const { data } = readJson(pkgPath);
+				if (data.name) dirToName.set(rel, data.name);
+			} catch {
+				/* ignore */
+			}
+		}
+	}
+	return dirToName;
+}
+
+function pruneWorkspaceDeps(root, removedNames, dryRun) {
+	const dirToName = scanWorkspace(root);
+	for (const [rel] of dirToName) {
+		const pkgPath = join(root, rel, "package.json");
+		const { data, indent, trailingNewline } = readJson(pkgPath);
+		let changed = false;
+		for (const field of DEP_FIELDS) {
+			if (!data[field]) continue;
+			for (const dep of Object.keys(data[field])) {
+				if (removedNames.has(dep)) {
+					delete data[field][dep];
+					changed = true;
+				}
+			}
+			if (data[field] && Object.keys(data[field]).length === 0) delete data[field];
+		}
+		if (changed) {
+			if (!dryRun) writeJson(pkgPath, data, indent, trailingNewline);
+			ok(`cleaned ${rel}/package.json`);
+		}
+	}
+
+	const rootPkg = join(root, "package.json");
+	if (!existsSync(rootPkg)) return;
+	const { data, indent, trailingNewline } = readJson(rootPkg);
+	let changed = false;
+	for (const field of DEP_FIELDS) {
+		if (!data[field]) continue;
+		for (const dep of Object.keys(data[field])) {
+			if (removedNames.has(dep)) {
+				delete data[field][dep];
+				changed = true;
+			}
+		}
+	}
+	if (changed) {
+		if (!dryRun) writeJson(rootPkg, data, indent, trailingNewline);
+		ok("cleaned root package.json workspace deps");
+	}
+}
+
+function pruneRootScripts(root, keepKeys, dryRun) {
+	const pkgPath = join(root, "package.json");
+	const { data, indent, trailingNewline } = readJson(pkgPath);
+	if (!data.scripts) return;
+	const keep = new Set(keepKeys);
+	const removed = [];
+	for (const key of Object.keys(data.scripts)) {
+		if (!keep.has(key) && /^(dev:|build:web$|web$|optimise$)/.test(key)) {
+			delete data.scripts[key];
+			removed.push(key);
+		}
+	}
+	if (removed.length) {
+		if (!dryRun) writeJson(pkgPath, data, indent, trailingNewline);
+		ok(`removed root scripts: ${removed.join(", ")}`);
+	}
+}
+
+function removePackageDeps(root, pkg, names, dryRun) {
+	const pkgPath = join(root, pkg, "package.json");
+	if (!existsSync(pkgPath)) return;
+	const { data, indent, trailingNewline } = readJson(pkgPath);
+	let changed = false;
+	for (const field of DEP_FIELDS) {
+		if (!data[field]) continue;
+		for (const name of names) {
+			if (name in data[field]) {
+				delete data[field][name];
+				changed = true;
+			}
+		}
+		if (data[field] && Object.keys(data[field]).length === 0) delete data[field];
+	}
+	if (changed) {
+		if (!dryRun) writeJson(pkgPath, data, indent, trailingNewline);
+		ok(`removed deps from ${pkg}: ${names.join(", ")}`);
+	}
+}
+
+export function scanDanglingImports(root, keepDirs, removedNames) {
+	if (!removedNames.size) return [];
+	const exts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".astro"]);
+	const results = [];
+	const patterns = [...removedNames].map((name) => ({
+		name,
+		re: new RegExp(`(?:from|import|require\\()\\s*['"]${escapeRe(name)}(?:/[^'"]*)?['"]`),
+	}));
+
+	const walk = (absDir, relDir) => {
+		let entries;
+		try {
+			entries = readdirSync(absDir);
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (entry === "node_modules" || entry === ".turbo" || entry === "dist" || entry === ".output" || entry.startsWith(".")) {
+				continue;
+			}
+			const abs = join(absDir, entry);
+			const rel = `${relDir}/${entry}`;
+			let st;
+			try {
+				st = statSync(abs);
+			} catch {
+				continue;
+			}
+			if (st.isDirectory()) walk(abs, rel);
+			else if (exts.has(entry.slice(entry.lastIndexOf(".")))) {
+				let content;
+				try {
+					content = readFileSync(abs, "utf8");
+				} catch {
+					continue;
+				}
+				for (const { name, re } of patterns) {
+					if (re.test(content)) {
+						results.push(`${rel}  (imports ${name})`);
+						break;
+					}
+				}
+			}
+		}
+	};
+
+	for (const rel of keepDirs) {
+		const abs = join(root, rel);
+		if (existsSync(abs)) walk(abs, rel);
+	}
+	return results;
+}
+
+/**
+ * @param {string} root
+ * @param {{ keep: string[], ops: object[] }} plan
+ * @param {{ dryRun?: boolean }} [opts]
+ */
+export function applyPlan(root, plan, opts = {}) {
+	const dryRun = Boolean(opts.dryRun);
+	const dirToName = scanWorkspace(root);
+	const removedNames = new Set();
+	for (const op of plan.ops) {
+		if (op.type === "delete" && dirToName.has(op.path)) {
+			removedNames.add(dirToName.get(op.path));
+		}
+	}
+
+	for (const op of plan.ops) {
+		if (op.type === "delete") {
+			if (!existsSync(join(root, op.path))) continue;
+			if (!dryRun) rmSync(join(root, op.path), { recursive: true, force: true });
+			ok(`removed ${op.path}`);
+		} else if (op.type === "write-file") {
+			const abs = join(root, op.path);
+			if (!dryRun) {
+				mkdirSync(dirname(abs), { recursive: true });
+				writeFileSync(abs, op.contents);
+			}
+			ok(`wrote ${op.path}`);
+		} else if (op.type === "patch-file") {
+			const abs = join(root, op.path);
+			if (!existsSync(abs)) {
+				warn(`skip patch, missing ${op.path}`);
+				continue;
+			}
+			const next = applyPatches(readFileSync(abs, "utf8"), op.patches);
+			if (!dryRun) writeFileSync(abs, next);
+			ok(`patched ${op.path}`);
+		} else if (op.type === "remove-nav-link") {
+			const abs = join(root, op.path);
+			if (!existsSync(abs)) continue;
+			const next = removeNavLink(readFileSync(abs, "utf8"), op.href);
+			if (!dryRun) writeFileSync(abs, next);
+			ok(`removed nav link ${op.href} from ${op.path}`);
+		} else if (op.type === "remove-package-deps") {
+			removePackageDeps(root, op.pkg, op.names, dryRun);
+		} else if (op.type === "prune-workspace-deps") {
+			pruneWorkspaceDeps(root, removedNames, dryRun);
+		} else if (op.type === "prune-root-scripts") {
+			pruneRootScripts(root, op.keepKeys, dryRun);
+		} else if (op.type === "write-starter") {
+			if (!dryRun) writeJson(join(root, ".starter.json"), op.contents, "\t", true);
+			ok("wrote .starter.json");
+		}
+	}
+
+	const dangling = dryRun
+		? []
+		: scanDanglingImports(root, plan.keep, removedNames);
+
+	return { removedNames: [...removedNames], dangling };
+}

--- a/scripts/setup/index.mjs
+++ b/scripts/setup/index.mjs
@@ -1,544 +1,110 @@
 #!/usr/bin/env node
 // @ts-check
 /**
- * Starter setup / scaffolding wizard.
+ * Starter setup wizard.
  *
- * Run this right after cloning the monorepo. It asks a few questions about which
- * stack you want, then removes every app / package / script you are NOT using and
- * cleans up the workspace manifests that reference them.
+ *   pnpm setup                 # interactive (arrow keys / space / enter)
+ *   pnpm setup --dry-run       # preview, change nothing
+ *   pnpm setup --yes           # accept defaults, no prompts
  *
  * Zero dependencies on purpose: it must run before `pnpm install`.
- *
- *   node scripts/setup/index.mjs            # interactive
- *   node scripts/setup/index.mjs --dry-run  # preview, change nothing
- *   node scripts/setup/index.mjs --yes      # accept defaults, no prompts
- *
- * NOTE: this only removes whole directories and prunes workspace dependencies in
- * the remaining package.json files. It does NOT rewrite your source code, so if a
- * file you keep still imports a package you removed, that import is reported as a
- * warning for you to fix by hand.
  */
 
-import { readFileSync, writeFileSync, existsSync, rmSync, readdirSync, statSync } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createInterface } from "node:readline";
-import { stdin, stdout, argv, exit } from "node:process";
+import { argv, exit } from "node:process";
 import { execSync } from "node:child_process";
+import { applyPlan } from "./apply.mjs";
+import { buildPlan, collectAnswers, describePlan, parseArgs, printHelp } from "./model.mjs";
+import { confirm, createPromptCtx, info, ok, paint, title, warn } from "./prompts.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
-// ---------------------------------------------------------------------------
-// CLI flags
-// ---------------------------------------------------------------------------
-const FLAGS = new Set(argv.slice(2));
-const DRY_RUN = FLAGS.has("--dry-run") || FLAGS.has("-n");
-const ASSUME_YES = FLAGS.has("--yes") || FLAGS.has("-y");
-
-// ---------------------------------------------------------------------------
-// tiny ansi helpers
-// ---------------------------------------------------------------------------
-const c = {
-	reset: "\x1b[0m",
-	bold: "\x1b[1m",
-	dim: "\x1b[2m",
-	red: "\x1b[31m",
-	green: "\x1b[32m",
-	yellow: "\x1b[33m",
-	blue: "\x1b[34m",
-	cyan: "\x1b[36m",
-};
-const paint = (color, s) => `${c[color]}${s}${c.reset}`;
-const log = (...a) => console.log(...a);
-const title = (s) => log(`\n${paint("bold", paint("cyan", s))}`);
-const warn = (s) => log(paint("yellow", `⚠ ${s}`));
-const ok = (s) => log(paint("green", `✓ ${s}`));
-const info = (s) => log(paint("dim", s));
-
-// ---------------------------------------------------------------------------
-// Feature model
-//
-// `dirs` are workspace directories (relative to repo root) that belong to a
-// feature. Core dirs are always kept. Anything that appears in a feature's dirs
-// but is not part of the final selection gets deleted.
-// ---------------------------------------------------------------------------
-const CORE_DIRS = ["packages/config", "packages/tailwind", "packages/modules"];
-
-/** @typedef {{ id: string, label: string, dirs: string[], rootScripts?: string[] }} Choice */
-
-const FRAMEWORKS = /** @type {Choice[]} */ ([
-	{
-		id: "solid",
-		label: "SolidStart  (apps/solid)",
-		dirs: ["apps/solid", "packages/router"],
-		rootScripts: ["build:web", "dev:solid", "web"],
-	},
-	{
-		id: "next",
-		label: "Next.js     (apps/next)",
-		dirs: ["apps/next"],
-		rootScripts: ["dev:next"],
-	},
-	{
-		id: "astro",
-		label: "Astro       (apps/astro · Taxi + data-modules)",
-		dirs: ["apps/astro"],
-		rootScripts: ["dev:astro"],
-	},
-]);
-
-const WEBGL = /** @type {Choice[]} */ ([
-	{ id: "three", label: "three.js  (packages/three)", dirs: ["packages/three", "packages/gl-context"] },
-	{ id: "ogl", label: "OGL       (packages/ogl)", dirs: ["packages/ogl", "packages/gl-context"] },
-	{ id: "none", label: "None      (no WebGL)", dirs: [] },
-]);
-
-/**
- * Optional yes/no features.
- * `requires` lists feature ids that must be enabled for this to be available.
- * `frameworks` restricts availability to certain framework choices.
- */
-const OPTIONS = [
-	{
-		id: "cms",
-		label: "Sanity CMS (studio + client package + sync scripts)",
-		dirs: ["apps/cms", "packages/sanity", "scripts/sanity-yaml", "scripts/sync-sanity"],
-		default: true,
-	},
-	{
-		id: "seo",
-		label: "SEO helpers package (depends on Sanity, Solid only)",
-		dirs: ["packages/seo"],
-		requires: ["cms"],
-		frameworks: ["solid"],
-		default: true,
-	},
-	{
-		id: "shopify",
-		label: "Shopify ecommerce package (Solid only)",
-		dirs: ["packages/shopify"],
-		frameworks: ["solid"],
-		default: true,
-	},
-	{
-		id: "images",
-		label: "Image / font optimise script (scripts/optimise)",
-		dirs: ["scripts/optimise"],
-		default: true,
-	},
-];
-
-// Empty / placeholder directories that ship as scaffolding stubs.
-const PLACEHOLDER_DIRS = ["packages/animation", "packages/types", "packages/ui"];
-
-// ---------------------------------------------------------------------------
-// prompt helpers
-//
-// A small line-queue reader so both interactive TTY typing AND piped input
-// (e.g. `printf '1\\n2\\n' | node ...`) work. node:readline/promises drops
-// buffered lines after the first question, so we roll our own queue.
-// ---------------------------------------------------------------------------
-const rl = createInterface({ input: stdin });
-const lineQueue = [];
-const waiters = [];
-let stdinClosed = false;
-rl.on("line", (line) => {
-	const w = waiters.shift();
-	if (w) w(line);
-	else lineQueue.push(line);
-});
-rl.on("close", () => {
-	stdinClosed = true;
-	while (waiters.length) waiters.shift()(null);
-});
-
-/** @param {string} prompt @returns {Promise<string|null>} */
-function question(prompt) {
-	stdout.write(prompt);
-	return new Promise((resolve) => {
-		if (lineQueue.length) resolve(lineQueue.shift());
-		else if (stdinClosed) resolve(null);
-		else waiters.push(resolve);
-	});
-}
-
-async function askSingle(question_text, choices, defaultIndex = 0) {
-	if (ASSUME_YES) return choices[defaultIndex];
-	title(question_text);
-	choices.forEach((ch, i) => {
-		const marker = i === defaultIndex ? paint("green", "›") : " ";
-		log(`  ${marker} ${paint("bold", String(i + 1))}. ${ch.label}`);
-	});
-	while (true) {
-		const raw = await question(paint("dim", `Choose [1-${choices.length}] (default ${defaultIndex + 1}): `));
-		if (raw === null) return choices[defaultIndex]; // EOF -> default
-		const ans = raw.trim();
-		if (ans === "") return choices[defaultIndex];
-		const n = Number(ans);
-		if (Number.isInteger(n) && n >= 1 && n <= choices.length) return choices[n - 1];
-		warn("Invalid choice, try again.");
-	}
-}
-
-async function askBool(question_text, def = true) {
-	if (ASSUME_YES) return def;
-	const hint = def ? "[Y/n]" : "[y/N]";
-	while (true) {
-		const raw = await question(`${paint("cyan", "?")} ${question_text} ${paint("dim", hint)} `);
-		if (raw === null) return def; // EOF -> default
-		const ans = raw.trim().toLowerCase();
-		if (ans === "") return def;
-		if (["y", "yes"].includes(ans)) return true;
-		if (["n", "no"].includes(ans)) return false;
-		warn("Please answer y or n.");
-	}
-}
-
-// ---------------------------------------------------------------------------
-// json io that preserves indentation + trailing newline
-// ---------------------------------------------------------------------------
-function readJson(path) {
-	const raw = readFileSync(path, "utf8");
-	const indentMatch = raw.match(/^[ \t]*(\t|  +)/m);
-	const indent = indentMatch ? indentMatch[1] : "  ";
-	const trailingNewline = raw.endsWith("\n");
-	return { data: JSON.parse(raw), indent, trailingNewline, raw };
-}
-
-function writeJson(path, data, indent, trailingNewline) {
-	let out = JSON.stringify(data, null, indent);
-	if (trailingNewline) out += "\n";
-	if (!DRY_RUN) writeFileSync(path, out);
-}
-
-// ---------------------------------------------------------------------------
-// workspace scanning: build a name <-> dir map for every member package.json
-// ---------------------------------------------------------------------------
-function scanWorkspace() {
-	const dirToName = new Map();
-	const nameToDir = new Map();
-	for (const group of ["apps", "packages", "scripts"]) {
-		const groupDir = join(ROOT, group);
-		if (!existsSync(groupDir)) continue;
-		for (const entry of readdirSync(groupDir)) {
-			const rel = `${group}/${entry}`;
-			const pkgPath = join(ROOT, rel, "package.json");
-			if (!existsSync(pkgPath)) continue;
-			try {
-				const { data } = readJson(pkgPath);
-				if (data.name) {
-					dirToName.set(rel, data.name);
-					nameToDir.set(data.name, rel);
-				}
-			} catch {
-				/* ignore unparseable */
-			}
-		}
-	}
-	return { dirToName, nameToDir };
-}
-
-// ---------------------------------------------------------------------------
-// directory helpers
-// ---------------------------------------------------------------------------
-function dirHasSource(rel) {
-	const abs = join(ROOT, rel);
-	if (!existsSync(abs)) return false;
-	for (const entry of readdirSync(abs)) {
-		if (entry === "node_modules" || entry === ".turbo" || entry === ".DS_Store") continue;
-		return true; // anything other than ignorable junk counts as content
-	}
-	return false;
-}
-
-// ---------------------------------------------------------------------------
-// main
-// ---------------------------------------------------------------------------
 async function main() {
-	title("Monorepo starter setup");
-	info("Pick the stack you want — everything else gets removed.");
-	if (DRY_RUN) warn("DRY RUN: no files will be changed.");
+	const args = parseArgs(argv.slice(2));
+	if (args.help) {
+		printHelp();
+		return;
+	}
 
-	// git safety
-	let dirty = false;
+	title("starter setup");
+	info("Pick a stack. Unused apps, packages, and feature files get removed.");
+	if (args.dryRun) warn("DRY RUN: no files will be changed.");
+	if (existsSync(join(ROOT, ".starter.json"))) {
+		warn("This repo already has a .starter.json — running again will delete more.");
+	}
+
+	const ctx = createPromptCtx(args.yes);
 	try {
-		const status = execSync("git status --porcelain", { cwd: ROOT, encoding: "utf8" });
-		dirty = status.trim().length > 0;
-	} catch {
-		warn("Not a git repository — you won't be able to `git checkout` to undo.");
-	}
-	if (dirty && !DRY_RUN) {
-		warn("You have uncommitted changes. This script deletes files; commit or stash first so you can revert.");
-		const cont = await askBool("Continue anyway?", false);
-		if (!cont) {
-			rl.close();
-			return;
+		let dirty = false;
+		try {
+			const status = execSync("git status --porcelain", { cwd: ROOT, encoding: "utf8" });
+			dirty = status.trim().length > 0;
+		} catch {
+			warn("Not a git repository — you won't be able to git checkout to undo.");
 		}
-	}
-
-	const { dirToName } = scanWorkspace();
-
-	// --- gather answers -----------------------------------------------------
-	const framework = await askSingle("Which framework do you want to keep?", FRAMEWORKS);
-	const webgl = await askSingle("Which WebGL setup do you want?", WEBGL);
-
-	/** @type {Record<string, boolean>} */
-	const opts = {};
-	for (const opt of OPTIONS) {
-		const fwOk = !opt.frameworks || opt.frameworks.includes(framework.id);
-		const reqOk = !opt.requires || opt.requires.every((r) => opts[r]);
-		if (!fwOk || !reqOk) {
-			opts[opt.id] = false; // unavailable -> removed
-			continue;
-		}
-		opts[opt.id] = await askBool(`Include ${opt.label}?`, opt.default);
-	}
-
-	let removePlaceholders = true;
-	const presentPlaceholders = PLACEHOLDER_DIRS.filter((d) => existsSync(join(ROOT, d)));
-	if (presentPlaceholders.length) {
-		removePlaceholders = await askBool(
-			`Remove ${presentPlaceholders.length} empty placeholder dir(s) (${presentPlaceholders.map((d) => basename(d)).join(", ")})?`,
-			true,
-		);
-	}
-
-	// --- compute keep / remove sets ----------------------------------------
-	const keepDirs = new Set([...CORE_DIRS]);
-	framework.dirs.forEach((d) => keepDirs.add(d));
-	webgl.dirs.forEach((d) => keepDirs.add(d));
-	for (const opt of OPTIONS) {
-		if (opts[opt.id]) opt.dirs.forEach((d) => keepDirs.add(d));
-	}
-
-	// universe of dirs this wizard knows about
-	const universe = new Set([
-		...CORE_DIRS,
-		...FRAMEWORKS.flatMap((f) => f.dirs),
-		...WEBGL.flatMap((w) => w.dirs),
-		...OPTIONS.flatMap((o) => o.dirs),
-	]);
-
-	const removeDirs = [];
-	for (const d of universe) {
-		if (!keepDirs.has(d) && existsSync(join(ROOT, d))) removeDirs.push(d);
-	}
-	if (removePlaceholders) {
-		for (const d of presentPlaceholders) if (!keepDirs.has(d)) removeDirs.push(d);
-	}
-	removeDirs.sort();
-
-	const removedNames = new Set(removeDirs.map((d) => dirToName.get(d)).filter(Boolean));
-
-	// --- plan: manifest edits ----------------------------------------------
-	const manifestEdits = []; // { path, rel, removedDeps: string[] }
-	for (const [rel] of dirToName) {
-		if (removeDirs.includes(rel)) continue; // dir is going away anyway
-		const pkgPath = join(ROOT, rel, "package.json");
-		const { data } = readJson(pkgPath);
-		const removed = [];
-		for (const field of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]) {
-			if (!data[field]) continue;
-			for (const dep of Object.keys(data[field])) {
-				if (removedNames.has(dep)) removed.push(`${field}:${dep}`);
+		if (dirty && !args.dryRun) {
+			warn("You have uncommitted changes. This script deletes files; commit or stash first so you can revert.");
+			if (!args.yes) {
+				const cont = await confirm(ctx, "Continue anyway?", false);
+				if (!cont) {
+					warn("Cancelled. Repo unchanged.");
+					return;
+				}
 			}
 		}
-		if (removed.length) manifestEdits.push({ rel, removedDeps: removed });
-	}
 
-	// root package.json scripts to prune
-	const rootPkgPath = join(ROOT, "package.json");
-	const rootScriptsToRemove = [];
-	for (const fw of FRAMEWORKS) {
-		if (fw.id === framework.id) continue;
-		(fw.rootScripts || []).forEach((s) => rootScriptsToRemove.push(s));
-	}
+		const answers = await collectAnswers(ROOT, args, ctx);
+		const plan = buildPlan(ROOT, answers);
 
-	// --- dangling source imports in kept dirs ------------------------------
-	// Only library packages get imported by name; apps (web/next/sanity) never do,
-	// and their bare names ("next", "web") collide with normal identifiers.
-	const importableRemovedNames = new Set(
-		removeDirs.filter((d) => d.startsWith("packages/")).map((d) => dirToName.get(d)).filter(Boolean),
-	);
-	const danglingWarnings = scanDanglingImports(keepDirs, importableRemovedNames, removeDirs);
+		title("cleanup plan");
+		console.log(describePlan(plan));
+		console.log("");
 
-	// --- show the plan ------------------------------------------------------
-	title("Plan");
-	log(paint("bold", "Framework: ") + framework.label.trim());
-	log(paint("bold", "WebGL:     ") + webgl.label.trim());
-	for (const opt of OPTIONS) {
-		log(paint("bold", `${opt.id.padEnd(10)} `) + (opts[opt.id] ? paint("green", "keep") : paint("red", "remove")));
-	}
-
-	if (removeDirs.length) {
-		title("Will DELETE these directories:");
-		removeDirs.forEach((d) => log(paint("red", `  - ${d}`) + (dirToName.get(d) ? paint("dim", `  (${dirToName.get(d)})`) : "")));
-	} else {
-		ok("Nothing to delete.");
-	}
-
-	if (manifestEdits.length) {
-		title("Will EDIT these package.json files (prune workspace deps):");
-		manifestEdits.forEach((e) => log(`  - ${e.rel}` + paint("dim", `  → ${e.removedDeps.join(", ")}`)));
-	}
-
-	const presentRootScripts = (() => {
-		const { data } = readJson(rootPkgPath);
-		return rootScriptsToRemove.filter((s) => data.scripts && s in data.scripts);
-	})();
-	if (presentRootScripts.length) {
-		title("Will REMOVE these root scripts:");
-		presentRootScripts.forEach((s) => log(paint("red", `  - ${s}`)));
-	}
-
-	if (danglingWarnings.length) {
-		title("Heads up — these KEPT files still import REMOVED packages (fix by hand):");
-		danglingWarnings.slice(0, 40).forEach((w) => log(paint("yellow", `  - ${w}`)));
-		if (danglingWarnings.length > 40) info(`  …and ${danglingWarnings.length - 40} more`);
-	}
-
-	// --- confirm + apply ----------------------------------------------------
-	if (DRY_RUN) {
-		title("Dry run complete — nothing changed.");
-		rl.close();
-		return;
-	}
-	if (!removeDirs.length && !manifestEdits.length && !presentRootScripts.length) {
-		ok("Workspace already matches your selection. Nothing to do.");
-		rl.close();
-		return;
-	}
-
-	const confirmed = await askBool(paint("red", "Apply these changes? This deletes files."), false);
-	if (!confirmed) {
-		warn("Aborted. No changes made.");
-		rl.close();
-		return;
-	}
-
-	// delete dirs
-	for (const d of removeDirs) {
-		rmSync(join(ROOT, d), { recursive: true, force: true });
-		ok(`removed ${d}`);
-	}
-
-	// prune manifests
-	for (const e of manifestEdits) {
-		const pkgPath = join(ROOT, e.rel, "package.json");
-		const { data, indent, trailingNewline } = readJson(pkgPath);
-		for (const field of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]) {
-			if (!data[field]) continue;
-			for (const dep of Object.keys(data[field])) {
-				if (removedNames.has(dep)) delete data[field][dep];
-			}
-			if (Object.keys(data[field]).length === 0) delete data[field];
-		}
-		writeJson(pkgPath, data, indent, trailingNewline);
-		ok(`cleaned ${e.rel}/package.json`);
-	}
-
-	// prune root scripts
-	if (presentRootScripts.length) {
-		const { data, indent, trailingNewline } = readJson(rootPkgPath);
-		for (const s of presentRootScripts) delete data.scripts[s];
-		writeJson(rootPkgPath, data, indent, trailingNewline);
-		ok("cleaned root scripts");
-	}
-
-	// persist the answers
-	const record = {
-		generatedAt: new Date().toISOString(),
-		framework: framework.id,
-		webgl: webgl.id,
-		options: opts,
-		removedDirs: removeDirs,
-		removedPackages: [...removedNames],
-	};
-	writeJson(join(ROOT, ".starter.json"), record, "\t", true);
-	ok("wrote .starter.json");
-
-	// offer install
-	title("Done.");
-	if (danglingWarnings.length) {
-		warn(`${danglingWarnings.length} source import(s) now point at removed packages — fix them before building.`);
-	}
-	const doInstall = await askBool("Run `pnpm install` now to refresh the lockfile?", true);
-	rl.close();
-	if (doInstall) {
-		log(paint("dim", "\n$ pnpm install\n"));
-		try {
-			execSync("pnpm install", { cwd: ROOT, stdio: "inherit" });
-		} catch {
-			warn("pnpm install failed — run it manually once the dangling imports are fixed.");
-		}
-	} else {
-		info("Remember to run `pnpm install` to regenerate the lockfile.");
-	}
-}
-
-// ---------------------------------------------------------------------------
-// scan kept source for imports of removed packages
-// ---------------------------------------------------------------------------
-function scanDanglingImports(keepDirs, removedNames, removeDirs) {
-	if (removedNames.size === 0) return [];
-	const exts = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
-	const results = [];
-	const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	// match `from "name"`, `import "name"`, `require("name")`, incl. subpaths
-	const patterns = [...removedNames].map((name) => ({
-		name,
-		re: new RegExp(`(?:from|import|require\\()\\s*['"]${esc(name)}(?:/[^'"]*)?['"]`),
-	}));
-
-	/** @param {string} absDir @param {string} relDir */
-	const walk = (absDir, relDir) => {
-		let entries;
-		try {
-			entries = readdirSync(absDir);
-		} catch {
+		if (args.dryRun) {
+			title("Dry run complete — nothing changed.");
 			return;
 		}
-		for (const entry of entries) {
-			if (entry === "node_modules" || entry === ".turbo" || entry === "dist" || entry === ".output" || entry.startsWith(".")) continue;
-			const abs = join(absDir, entry);
-			const rel = `${relDir}/${entry}`;
-			let st;
+
+		const confirmed = args.yes || (await confirm(ctx, "Apply this cleanup? This deletes unused apps, packages, and feature files.", false));
+		if (!confirmed) {
+			warn("Cancelled. Repo unchanged.");
+			return;
+		}
+
+		const result = applyPlan(ROOT, plan);
+		title("Done.");
+		if (result.dangling.length) {
+			warn(`${result.dangling.length} kept file(s) still import removed packages:`);
+			for (const line of result.dangling.slice(0, 40)) console.log(paint("yellow", `  - ${line}`));
+			if (result.dangling.length > 40) info(`  …and ${result.dangling.length - 40} more`);
+		} else {
+			ok("No dangling workspace imports in kept apps.");
+		}
+
+		if (answers.runInstall) {
+			console.log(paint("dim", "\n$ pnpm install\n"));
 			try {
-				st = statSync(abs);
+				execSync("pnpm install", { cwd: ROOT, stdio: "inherit" });
 			} catch {
-				continue;
+				warn("pnpm install failed — run it manually if the lockfile still lists removed packages.");
 			}
-			if (st.isDirectory()) {
-				walk(abs, rel);
-			} else if (exts.has(entry.slice(entry.lastIndexOf(".")))) {
-				let content;
-				try {
-					content = readFileSync(abs, "utf8");
-				} catch {
-					continue;
-				}
-				for (const { name, re } of patterns) {
-					if (re.test(content)) {
-						results.push(`${rel}  (imports ${name})`);
-						break;
-					}
-				}
-			}
+		} else {
+			info("Remember to run `pnpm install` to regenerate the lockfile.");
 		}
-	};
-
-	// only scan dirs we keep (and aren't being removed)
-	for (const rel of keepDirs) {
-		if (removeDirs.includes(rel)) continue;
-		const abs = join(ROOT, rel);
-		if (existsSync(abs)) walk(abs, rel);
+	} catch (err) {
+		if (err instanceof Error && err.message === "cancelled") {
+			warn("Cancelled.");
+			exit(130);
+		}
+		throw err;
+	} finally {
+		ctx.close();
 	}
-	return results;
 }
 
-main()
-	.catch((err) => {
-		rl.close();
-		console.error(paint("red", "\nSetup failed:"), err);
-		exit(1);
-	});
+main().catch((err) => {
+	console.error(paint("red", "\nSetup failed:"), err);
+	exit(1);
+});

--- a/scripts/setup/model.mjs
+++ b/scripts/setup/model.mjs
@@ -1,0 +1,483 @@
+// @ts-check
+/**
+ * Feature graph + cleanup plan for the starter wizard.
+ * The plan is data: apply.mjs is the only place that touches the filesystem
+ * for writes (buildPlan may stat paths so the preview stays honest).
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { confirm, multiSelect, select } from "./prompts.mjs";
+
+export const FRAMEWORKS = [
+	{ value: "solid", label: "SolidStart", hint: "Solid + @acme/router" },
+	{ value: "next", label: "Next.js", hint: "App Router + view transitions" },
+	{ value: "astro", label: "Astro", hint: "Taxi + data-modules" },
+];
+
+export const CMS_OPTIONS = [
+	{ value: "sanity", label: "Sanity", hint: "Studio + @local/sanity" },
+	{ value: "none", label: "None", hint: "Static pages, no CMS" },
+];
+
+export function webglOptions(root) {
+	const options = [
+		{ value: "three", label: "three.js", hint: "@local/three + webgl routes" },
+		{ value: "none", label: "None", hint: "No WebGL packages or pages" },
+	];
+	if (existsSync(join(root, "packages/ogl"))) {
+		options.splice(1, 0, { value: "ogl", label: "OGL", hint: "@local/ogl" });
+	}
+	return options;
+}
+
+const CORE_KEEP = ["packages/config", "packages/tailwind", "packages/modules"];
+
+const FRAMEWORK_DIRS = {
+	solid: ["apps/solid", "packages/router"],
+	next: ["apps/next"],
+	astro: ["apps/astro"],
+};
+
+const CMS_DIRS = {
+	sanity: ["apps/cms", "packages/sanity", "scripts/sanity-yaml", "scripts/sync-sanity"],
+};
+
+const WEBGL_DIRS = {
+	three: ["packages/three", "packages/gl-context"],
+	ogl: ["packages/ogl", "packages/gl-context"],
+};
+
+const EXTRA_DIRS = {
+	seo: ["packages/seo"],
+	shopify: ["packages/shopify"],
+	optimise: ["scripts/optimise"],
+};
+
+const PLACEHOLDER_DIRS = ["packages/animation", "packages/types", "packages/ui"];
+
+const ALWAYS_KEEP_SCRIPTS = [
+	"build",
+	"dev",
+	"test",
+	"test:watch",
+	"typecheck",
+	"check",
+	"scaffold",
+	"setup",
+];
+
+const ROOT_SCRIPT_KEYS = {
+	solid: ["dev:solid", "build:web", "web"],
+	next: ["dev:next"],
+	astro: ["dev:astro"],
+	cms: ["dev:cms"],
+	optimise: ["optimise"],
+};
+
+const CANDIDATE_DIRS = [
+	"apps/solid",
+	"apps/next",
+	"apps/astro",
+	"apps/cms",
+	"packages/router",
+	"packages/sanity",
+	"packages/seo",
+	"packages/shopify",
+	"packages/three",
+	"packages/ogl",
+	"packages/gl-context",
+	"scripts/sanity-yaml",
+	"scripts/sync-sanity",
+	"scripts/optimise",
+	...PLACEHOLDER_DIRS,
+];
+
+function extraChoices(answers) {
+	const extras = [];
+	if (answers.framework === "solid" && answers.cms === "sanity") {
+		extras.push({
+			value: "seo",
+			label: "SEO package",
+			hint: "@local/seo + SanityMeta",
+		});
+	}
+	if (answers.framework === "solid") {
+		extras.push({
+			value: "shopify",
+			label: "Shopify",
+			hint: "@local/shopify + /_/shop",
+		});
+	}
+	extras.push({
+		value: "optimise",
+		label: "Image & font optimise",
+		hint: "Keep scripts/optimise",
+	});
+	return extras;
+}
+
+export function defaultAnswers() {
+	return {
+		framework: "solid",
+		cms: "sanity",
+		webgl: "three",
+		extras: ["seo", "shopify", "optimise"],
+		runInstall: true,
+	};
+}
+
+export function parseArgs(argv) {
+	const args = { dryRun: false, yes: false, help: false };
+	for (const arg of argv) {
+		if (arg === "--dry-run" || arg === "-n") args.dryRun = true;
+		else if (arg === "--yes" || arg === "-y") args.yes = true;
+		else if (arg === "--help" || arg === "-h") args.help = true;
+	}
+	return args;
+}
+
+export function printHelp() {
+	console.log(`
+Usage: pnpm setup [--yes] [--dry-run]
+
+Interactive wizard. Arrow keys to move, space to toggle extras, enter to confirm.
+
+  --yes, -y      Use defaults (Solid + Sanity + three.js + all extras)
+  --dry-run, -n  Print the cleanup plan without changing the repo
+  --help, -h     Show this help
+`);
+}
+
+/**
+ * @param {string} root
+ * @param {{ yes?: boolean }} args
+ * @param {import("./prompts.mjs").PromptCtx} ctx
+ */
+export async function collectAnswers(root, args, ctx) {
+	if (args.yes) return defaultAnswers();
+
+	const answers = {
+		framework: "solid",
+		cms: "sanity",
+		webgl: "three",
+		/** @type {string[]} */
+		extras: [],
+		runInstall: true,
+	};
+
+	answers.framework = await select(ctx, "Framework", FRAMEWORKS, 0);
+	answers.cms = await select(ctx, "CMS", CMS_OPTIONS, 0);
+	answers.webgl = await select(ctx, "WebGL", webglOptions(root), 0);
+
+	const extras = extraChoices(answers);
+	answers.extras = extras.length ? await multiSelect(ctx, "Extras", extras) : [];
+	answers.runInstall = await confirm(ctx, "Run pnpm install after cleanup?", true);
+	return answers;
+}
+
+function hasExtra(answers, name) {
+	return answers.extras.includes(name);
+}
+
+function navLink(file, href) {
+	return { type: "remove-nav-link", path: file, href };
+}
+
+function patchFile(path, patches) {
+	return { type: "patch-file", path, patches };
+}
+
+function replaceFile(path, contents) {
+	return { type: "write-file", path, contents };
+}
+
+function deletePaths(paths) {
+	return paths.map((path) => ({ type: "delete", path }));
+}
+
+const CLIENT_RECT_NO_GL = `import { Scroll } from "./scroll";
+import { viewport } from "../stores/viewportStore";
+
+export interface ClientRectBounds {
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+  left: number;
+  right: number;
+  wh: number;
+  ww: number;
+  offset: number;
+}
+
+export const clientRect = (element: HTMLElement): ClientRectBounds => {
+  const bounds = element.getBoundingClientRect();
+  const { scroll } = Scroll.lenis;
+
+  return {
+    top: bounds.top + scroll,
+    bottom: bounds.bottom + scroll,
+    width: bounds.width,
+    height: bounds.height,
+    left: bounds.left,
+    right: bounds.right,
+    wh: viewport.size.height,
+    ww: viewport.size.width,
+    offset: bounds.top + scroll,
+  };
+};
+`;
+
+const STATIC_HOME_SOLID = `export default function Home() {
+	return (
+		<main class="flex min-h-svh flex-col">
+			<section class="flex flex-1 items-center px-gx">
+				<h1 class="col-span-full text-[clamp(2.5rem,8vw,7rem)] font-medium leading-[0.9] tracking-tight">
+					Starter
+				</h1>
+			</section>
+		</main>
+	);
+}
+`;
+
+const STATIC_HOME_NEXT = `export default function Home() {
+  return (
+    <main className="flex min-h-svh flex-col">
+      <section className="flex flex-1 items-center px-gx">
+        <h1 className="col-span-full text-[clamp(2.5rem,8vw,7rem)] font-medium leading-[0.9] tracking-tight">
+          Starter
+        </h1>
+      </section>
+    </main>
+  );
+}
+`;
+
+const STATIC_HOME_ASTRO = `---
+import PageLayout from "~/layouts/PageLayout.astro";
+import Nav from "~/components/Nav.astro";
+---
+
+<PageLayout title="Home">
+  <Nav slot="chrome" />
+  <section class="flex min-h-svh flex-1 items-center px-gx">
+    <h1 class="col-span-full text-[clamp(2.5rem,8vw,7rem)] font-medium leading-[0.9] tracking-tight">
+      Starter
+    </h1>
+  </section>
+</PageLayout>
+`;
+
+function wantsSeo(answers) {
+	return (
+		answers.framework === "solid" &&
+		answers.cms === "sanity" &&
+		hasExtra(answers, "seo")
+	);
+}
+
+function wantsShopify(answers) {
+	return answers.framework === "solid" && hasExtra(answers, "shopify");
+}
+
+function rootScriptKeys(answers) {
+	const keys = [...ALWAYS_KEEP_SCRIPTS, ...(ROOT_SCRIPT_KEYS[answers.framework] ?? [])];
+	if (answers.cms !== "none") keys.push(...ROOT_SCRIPT_KEYS.cms);
+	if (hasExtra(answers, "optimise")) keys.push(...ROOT_SCRIPT_KEYS.optimise);
+	return keys;
+}
+
+export function buildPlan(root, answers) {
+	const keep = new Set(CORE_KEEP);
+	for (const dir of FRAMEWORK_DIRS[answers.framework] ?? []) keep.add(dir);
+	if (answers.cms !== "none") {
+		for (const dir of CMS_DIRS[answers.cms] ?? []) keep.add(dir);
+	}
+	if (answers.webgl !== "none") {
+		for (const dir of WEBGL_DIRS[answers.webgl] ?? []) keep.add(dir);
+	}
+	if (wantsSeo(answers)) {
+		for (const dir of EXTRA_DIRS.seo) keep.add(dir);
+	}
+	if (wantsShopify(answers)) {
+		for (const dir of EXTRA_DIRS.shopify) keep.add(dir);
+	}
+	if (hasExtra(answers, "optimise")) {
+		for (const dir of EXTRA_DIRS.optimise) keep.add(dir);
+	}
+
+	/** @type {object[]} */
+	const ops = [];
+
+	for (const dir of CANDIDATE_DIRS) {
+		if (!keep.has(dir) && existsSync(join(root, dir))) {
+			ops.push({ type: "delete", path: dir });
+		}
+	}
+
+	if (answers.webgl === "none") {
+		if (answers.framework === "solid") {
+			ops.push(...deletePaths([
+				"apps/solid/src/routes/_/webgl",
+				"apps/solid/src/lib/stores/webglStore.ts",
+			]));
+			ops.push(navLink("apps/solid/src/components/Nav.tsx", "/_/webgl"));
+			ops.push(patchFile("apps/solid/src/app.tsx", [
+				{ type: "remove-const", name: "ClientCanvas" },
+				{ type: "remove-jsx", tag: "ClientCanvas" },
+				{ type: "sweep-imports" },
+			]));
+			ops.push(replaceFile("apps/solid/src/lib/utils/clientRect.ts", CLIENT_RECT_NO_GL));
+			ops.push(patchFile("apps/solid/app.config.ts", [
+				{ type: "remove-line-includes", needles: ["three"] },
+			]));
+			ops.push({
+				type: "remove-package-deps",
+				pkg: "apps/solid",
+				names: ["three", "@local/three", "@local/gl-context"],
+			});
+		}
+		if (answers.framework === "next") {
+			ops.push(...deletePaths([
+				"apps/next/app/%5F/webgl",
+				"apps/next/components/WebglCanvas.tsx",
+				"apps/next/lib/clientRectGl.ts",
+				"apps/next/lib/webglStore.ts",
+				"apps/next/lib/webgl-assets.ts",
+				"apps/next/lib/gui.ts",
+			]));
+			ops.push(navLink("apps/next/components/Nav.tsx", "/_/webgl"));
+			ops.push(patchFile("apps/next/components/AppShell.tsx", [
+				{ type: "remove-const", name: "WebglCanvas" },
+				{ type: "remove-jsx", tag: "WebglCanvas" },
+				{ type: "sweep-imports" },
+			]));
+			ops.push(patchFile("apps/next/next.config.ts", [
+				{ type: "empty-transpile-packages" },
+			]));
+			ops.push({
+				type: "remove-package-deps",
+				pkg: "apps/next",
+				names: ["@local/three"],
+			});
+		}
+	}
+
+	if (answers.cms === "none") {
+		if (answers.framework === "solid") {
+			ops.push(...deletePaths([
+				"apps/solid/src/components/slices",
+				"apps/solid/src/routes/_/content",
+				"apps/solid/src/routes/api/robots.txt.ts",
+				"apps/solid/src/routes/api/preview-enable.ts",
+				"apps/solid/src/routes/api/preview-disable.ts",
+			]));
+			ops.push(navLink("apps/solid/src/components/Nav.tsx", "/_/content"));
+			ops.push(replaceFile("apps/solid/src/routes/(home).tsx", STATIC_HOME_SOLID));
+			ops.push(patchFile("apps/solid/src/app.tsx", [
+				{ type: "remove-robots-link" },
+				{ type: "sweep-imports" },
+			]));
+		}
+		if (answers.framework === "next") {
+			ops.push(...deletePaths([
+				"apps/next/lib/home-seo.ts",
+				"apps/next/app/%5F/content",
+			]));
+			ops.push(navLink("apps/next/components/Nav.tsx", "/_/content"));
+			ops.push(replaceFile("apps/next/app/page.tsx", STATIC_HOME_NEXT));
+		}
+		if (answers.framework === "astro") {
+			ops.push(...deletePaths([
+				"apps/astro/src/pages/_/content.astro",
+				"apps/astro/src/components/slices",
+			]));
+			ops.push(navLink("apps/astro/src/components/Nav.astro", "/_/content"));
+			ops.push(replaceFile("apps/astro/src/pages/index.astro", STATIC_HOME_ASTRO));
+		}
+	} else if (answers.framework === "solid" && !hasExtra(answers, "seo")) {
+		ops.push(patchFile("apps/solid/src/routes/(home).tsx", [
+			{ type: "remove-jsx", tag: "SanityMeta" },
+			{ type: "sweep-imports" },
+		]));
+		ops.push(patchFile("apps/solid/src/routes/_/animation/(animation).tsx", [
+			{ type: "remove-jsx", tag: "SanityMeta" },
+			{ type: "sweep-imports" },
+		]));
+		if (wantsShopify(answers)) {
+			ops.push(patchFile("apps/solid/src/routes/_/shop/[handle].tsx", [
+				{ type: "remove-jsx", tag: "SchemaMarkup" },
+				{ type: "sweep-imports" },
+			]));
+		}
+	}
+
+	if (answers.framework === "solid" && !wantsShopify(answers)) {
+		ops.push(...deletePaths([
+			"apps/solid/src/routes/_/shop",
+			"apps/solid/src/routes/_/shop.tsx",
+			"apps/solid/src/components/shop",
+			"apps/solid/src/lib/shopify",
+			"apps/solid/src/routes/api/shopify",
+		]));
+		ops.push(navLink("apps/solid/src/components/Nav.tsx", "/_/shop"));
+		ops.push(patchFile("apps/solid/app.config.ts", [
+			{ type: "strip-shopify-config" },
+		]));
+	}
+
+	ops.push({ type: "prune-workspace-deps" });
+	ops.push({ type: "prune-root-scripts", keepKeys: rootScriptKeys(answers) });
+	ops.push({
+		type: "write-starter",
+		contents: {
+			framework: answers.framework,
+			cms: answers.cms,
+			webgl: answers.webgl,
+			extras: answers.extras,
+			createdAt: new Date().toISOString(),
+		},
+	});
+
+	return {
+		answers,
+		keep: [...keep].sort(),
+		ops: ops.filter((op) => op.type !== "delete" || existsSync(join(root, op.path))),
+	};
+}
+
+export function describePlan(plan) {
+	const lines = [];
+	const deletes = plan.ops.filter((op) => op.type === "delete").map((op) => op.path);
+	const writes = plan.ops.filter((op) => op.type === "write-file").map((op) => op.path);
+	const patches = plan.ops.filter((op) => op.type === "patch-file").map((op) => op.path);
+	const navs = plan.ops
+		.filter((op) => op.type === "remove-nav-link")
+		.map((op) => `${op.path} (${op.href})`);
+
+	lines.push(`  Framework   ${plan.answers.framework}`);
+	lines.push(`  CMS         ${plan.answers.cms}`);
+	lines.push(`  WebGL       ${plan.answers.webgl}`);
+	lines.push(`  Extras      ${plan.answers.extras.join(", ") || "none"}`);
+	lines.push("");
+	lines.push(`  Keep        ${plan.keep.join(", ")}`);
+	if (deletes.length) {
+		lines.push("");
+		lines.push("  Delete");
+		for (const path of deletes) lines.push(`    - ${path}`);
+	}
+	if (writes.length) {
+		lines.push("");
+		lines.push("  Replace");
+		for (const path of writes) lines.push(`    - ${path}`);
+	}
+	if (patches.length || navs.length) {
+		lines.push("");
+		lines.push("  Patch");
+		for (const path of [...new Set(patches)]) lines.push(`    - ${path}`);
+		for (const nav of navs) lines.push(`    - ${nav}`);
+	}
+	return lines.join("\n");
+}

--- a/scripts/setup/model.mjs
+++ b/scripts/setup/model.mjs
@@ -5,7 +5,7 @@
  * for writes (buildPlan may stat paths so the preview stays honest).
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { confirm, multiSelect, select } from "./prompts.mjs";
 
@@ -317,6 +317,17 @@ export function buildPlan(root, answers) {
 		}
 	}
 
+	if (answers.framework === "solid") {
+		const solidApp = join(root, "apps/solid");
+		if (existsSync(solidApp)) {
+			for (const name of readdirSync(solidApp)) {
+				if (name.startsWith("app.config.timestamp_")) {
+					ops.push({ type: "delete", path: `apps/solid/${name}` });
+				}
+			}
+		}
+	}
+
 	if (answers.webgl === "none") {
 		if (answers.framework === "solid") {
 			ops.push(...deletePaths([
@@ -331,7 +342,7 @@ export function buildPlan(root, answers) {
 			]));
 			ops.push(replaceFile("apps/solid/src/lib/utils/clientRect.ts", CLIENT_RECT_NO_GL));
 			ops.push(patchFile("apps/solid/app.config.ts", [
-				{ type: "remove-line-includes", needles: ["three"] },
+				{ type: "strip-three-config" },
 			]));
 			ops.push({
 				type: "remove-package-deps",
@@ -397,11 +408,15 @@ export function buildPlan(root, answers) {
 			ops.push(navLink("apps/astro/src/components/Nav.astro", "/_/content"));
 			ops.push(replaceFile("apps/astro/src/pages/index.astro", STATIC_HOME_ASTRO));
 		}
-	} else if (answers.framework === "solid" && !hasExtra(answers, "seo")) {
-		ops.push(patchFile("apps/solid/src/routes/(home).tsx", [
-			{ type: "remove-jsx", tag: "SanityMeta" },
-			{ type: "sweep-imports" },
-		]));
+	}
+
+	if (answers.framework === "solid" && !wantsSeo(answers)) {
+		if (answers.cms !== "none") {
+			ops.push(patchFile("apps/solid/src/routes/(home).tsx", [
+				{ type: "remove-jsx", tag: "SanityMeta" },
+				{ type: "sweep-imports" },
+			]));
+		}
 		ops.push(patchFile("apps/solid/src/routes/_/animation/(animation).tsx", [
 			{ type: "remove-jsx", tag: "SanityMeta" },
 			{ type: "sweep-imports" },

--- a/scripts/setup/prompts.mjs
+++ b/scripts/setup/prompts.mjs
@@ -1,0 +1,324 @@
+// @ts-check
+/**
+ * Zero-dep prompts. Arrow-key select when stdin is a TTY;
+ * numbered / y-n fallback for pipes and `--yes`.
+ */
+
+import { createInterface } from "node:readline";
+import { stdin, stdout } from "node:process";
+
+const ESC = "\x1b";
+export const c = {
+	reset: `${ESC}[0m`,
+	bold: `${ESC}[1m`,
+	dim: `${ESC}[2m`,
+	red: `${ESC}[31m`,
+	green: `${ESC}[32m`,
+	yellow: `${ESC}[33m`,
+	cyan: `${ESC}[36m`,
+	inverse: `${ESC}[7m`,
+};
+export const paint = (color, s) => `${c[color]}${s}${c.reset}`;
+export const log = (...a) => console.log(...a);
+export const title = (s) => log(`\n${paint("bold", paint("cyan", s))}`);
+export const warn = (s) => log(paint("yellow", `⚠ ${s}`));
+export const ok = (s) => log(paint("green", `✓ ${s}`));
+export const info = (s) => log(paint("dim", s));
+
+const HIDE = `${ESC}[?25l`;
+const SHOW = `${ESC}[?25h`;
+const CLEAR_LINE = `${ESC}[2K`;
+
+export const isInteractive = () => Boolean(stdin.isTTY && stdout.isTTY);
+
+/** @typedef {{ input: import("node:readline").Interface, assumeYes: boolean, close: () => void }} PromptCtx */
+
+export function createPromptCtx(assumeYes) {
+	/** @type {import("node:readline").Interface | null} */
+	let rl = null;
+	/** @type {string[]} */
+	const lineQueue = [];
+	/** @type {((line: string|null) => void)[]} */
+	const waiters = [];
+	let stdinClosed = false;
+
+	function ensureRl() {
+		if (rl) return;
+		// Only attach readline for piped / numbered fallback. A TTY raw-mode
+		// select cannot share stdin with readline or keypresses get stolen.
+		rl = createInterface({ input: stdin, terminal: false });
+		rl.on("line", (line) => {
+			const w = waiters.shift();
+			if (w) w(line);
+			else lineQueue.push(line);
+		});
+		rl.on("close", () => {
+			stdinClosed = true;
+			while (waiters.length) waiters.shift()?.(null);
+		});
+	}
+
+	/** @param {string} prompt */
+	function readLine(prompt) {
+		ensureRl();
+		stdout.write(prompt);
+		return new Promise((resolve) => {
+			if (lineQueue.length) resolve(lineQueue.shift() ?? "");
+			else if (stdinClosed) resolve(null);
+			else waiters.push(resolve);
+		});
+	}
+
+	return {
+		assumeYes,
+		readLine,
+		close() {
+			restoreTerminal();
+			rl?.close();
+		},
+	};
+}
+
+function restoreTerminal() {
+	if (!stdin.isTTY) return;
+	try {
+		stdin.setRawMode(false);
+	} catch {
+		/* already cooked */
+	}
+	stdout.write(SHOW);
+}
+
+function onSigint(handler) {
+	const wrapped = () => handler();
+	process.on("SIGINT", wrapped);
+	return () => process.off("SIGINT", wrapped);
+}
+
+/**
+ * @param {string} key
+ * @returns {"up"|"down"|"left"|"right"|"enter"|"space"|"escape"|"interrupt"|{type:"char", value: string}}
+ */
+function parseKey(key) {
+	if (key === "\u0003") return "interrupt";
+	if (key === "\r" || key === "\n") return "enter";
+	if (key === " " || key === "\u00a0") return "space";
+	if (key === "\u001b" || key === "\u001b\u001b") return "escape";
+	if (key === "\u001b[A" || key === "\u001bOA" || key === "k") return "up";
+	if (key === "\u001b[B" || key === "\u001bOB" || key === "j") return "down";
+	if (key === "\u001b[D" || key === "\u001bOD" || key === "h") return "left";
+	if (key === "\u001b[C" || key === "\u001bOC" || key === "l") return "right";
+	return { type: "char", value: key };
+}
+
+/**
+ * @template T
+ * @param {PromptCtx} ctx
+ * @param {string} message
+ * @param {{ value: T, label: string, hint?: string }[]} options
+ * @param {number} [initial]
+ * @returns {Promise<T>}
+ */
+export async function select(ctx, message, options, initial = 0) {
+	if (ctx.assumeYes) return options[initial].value;
+	if (!isInteractive()) return selectFallback(ctx, message, options, initial);
+
+	let index = Math.min(Math.max(initial, 0), options.length - 1);
+	let drawn = 0;
+
+	const render = () => {
+		const lines = [
+			paint("bold", paint("cyan", message)),
+			paint("dim", "↑↓ move · enter select · 1–9 jump"),
+			...options.map((opt, i) => {
+				const on = i === index;
+				const mark = on ? paint("green", "❯") : " ";
+				const label = on ? paint("bold", opt.label) : opt.label;
+				const hint = opt.hint ? paint("dim", `  ${opt.hint}`) : "";
+				return `  ${mark} ${label}${hint}`;
+			}),
+		];
+		redraw(lines, drawn);
+		drawn = lines.length;
+	};
+
+	return rawLoop(render, (event) => {
+		if (event === "up") index = (index - 1 + options.length) % options.length;
+		else if (event === "down") index = (index + 1) % options.length;
+		else if (event === "enter") return { done: options[index].value };
+		else if (typeof event === "object" && event.type === "char") {
+			const n = Number(event.value);
+			if (Number.isInteger(n) && n >= 1 && n <= options.length) {
+				return { done: options[n - 1].value };
+			}
+		}
+		return { redraw: true };
+	}, () => drawn);
+}
+
+/**
+ * @param {PromptCtx} ctx
+ * @param {string} message
+ * @param {boolean} [def]
+ */
+export async function confirm(ctx, message, def = true) {
+	if (ctx.assumeYes) return def;
+	if (!isInteractive()) return confirmFallback(ctx, message, def);
+
+	const options = [
+		{ value: true, label: "Yes" },
+		{ value: false, label: "No" },
+	];
+	return select(ctx, message, options, def ? 0 : 1);
+}
+
+/**
+ * @param {PromptCtx} ctx
+ * @param {string} message
+ * @param {{ value: string, label: string, hint?: string, selected?: boolean }[]} options
+ * @returns {Promise<string[]>}
+ */
+export async function multiSelect(ctx, message, options) {
+	if (!options.length) return [];
+	if (ctx.assumeYes) return options.filter((o) => o.selected !== false).map((o) => o.value);
+	if (!isInteractive()) return multiFallback(ctx, message, options);
+
+	let index = 0;
+	const picked = options.map((o) => o.selected !== false);
+	let drawn = 0;
+
+	const render = () => {
+		const lines = [
+			paint("bold", paint("cyan", message)),
+			paint("dim", "↑↓ move · space toggle · enter confirm"),
+			...options.map((opt, i) => {
+				const on = i === index;
+				const box = picked[i] ? paint("green", "●") : paint("dim", "○");
+				const mark = on ? paint("green", "❯") : " ";
+				const label = on ? paint("bold", opt.label) : opt.label;
+				const hint = opt.hint ? paint("dim", `  ${opt.hint}`) : "";
+				return `  ${mark} ${box} ${label}${hint}`;
+			}),
+		];
+		redraw(lines, drawn);
+		drawn = lines.length;
+	};
+
+	return rawLoop(render, (event) => {
+		if (event === "up") index = (index - 1 + options.length) % options.length;
+		else if (event === "down") index = (index + 1) % options.length;
+		else if (event === "space") picked[index] = !picked[index];
+		else if (event === "enter") {
+			return { done: options.filter((_, i) => picked[i]).map((o) => o.value) };
+		} else if (typeof event === "object" && event.type === "char") {
+			const n = Number(event.value);
+			if (Number.isInteger(n) && n >= 1 && n <= options.length) {
+				picked[n - 1] = !picked[n - 1];
+				index = n - 1;
+			}
+		}
+		return { redraw: true };
+	}, () => drawn);
+}
+
+/**
+ * @template T
+ * @param {() => void} render
+ * @param {(event: ReturnType<typeof parseKey>) => { done?: T, redraw?: boolean }} handle
+ * @param {() => number} drawn
+ */
+function rawLoop(render, handle, drawn) {
+	return new Promise((resolve, reject) => {
+		stdin.setRawMode(true);
+		stdin.resume();
+		stdin.setEncoding("utf8");
+		stdout.write(HIDE);
+		render();
+
+		const offInt = onSigint(() => {
+			cleanup();
+			stdout.write("\n");
+			reject(new Error("cancelled"));
+		});
+
+		const onData = (chunk) => {
+			const event = parseKey(String(chunk));
+			if (event === "interrupt") {
+				cleanup();
+				stdout.write("\n");
+				reject(new Error("cancelled"));
+				return;
+			}
+			if (event === "escape") return;
+			const result = handle(event);
+			if (result && "done" in result) {
+				cleanup();
+				stdout.write("\n");
+				resolve(result.done);
+				return;
+			}
+			if (result?.redraw) render();
+		};
+
+		function cleanup() {
+			stdin.off("data", onData);
+			offInt();
+			restoreTerminal();
+			// leave the final render on screen
+			void drawn;
+		}
+
+		stdin.on("data", onData);
+	});
+}
+
+function redraw(lines, previous) {
+	if (previous > 0) stdout.write(`${ESC}[${previous}A`);
+	for (const line of lines) stdout.write(`${CLEAR_LINE}${line}\n`);
+	if (previous > lines.length) {
+		for (let i = 0; i < previous - lines.length; i++) stdout.write(`${CLEAR_LINE}\n`);
+		stdout.write(`${ESC}[${previous - lines.length}A`);
+	}
+}
+
+/** @template T */
+async function selectFallback(ctx, message, options, initial) {
+	title(message);
+	options.forEach((opt, i) => {
+		const mark = i === initial ? paint("green", "›") : " ";
+		log(`  ${mark} ${paint("bold", String(i + 1))}. ${opt.label}${opt.hint ? paint("dim", `  ${opt.hint}`) : ""}`);
+	});
+	while (true) {
+		const raw = await ctx.readLine(paint("dim", `Choose [1-${options.length}] (default ${initial + 1}): `));
+		if (raw === null) return options[initial].value;
+		const ans = raw.trim();
+		if (ans === "") return options[initial].value;
+		const n = Number(ans);
+		if (Number.isInteger(n) && n >= 1 && n <= options.length) return options[n - 1].value;
+		warn("Invalid choice, try again.");
+	}
+}
+
+async function confirmFallback(ctx, message, def) {
+	const hint = def ? "[Y/n]" : "[y/N]";
+	while (true) {
+		const raw = await ctx.readLine(`${paint("cyan", "?")} ${message} ${paint("dim", hint)} `);
+		if (raw === null) return def;
+		const ans = raw.trim().toLowerCase();
+		if (ans === "") return def;
+		if (["y", "yes"].includes(ans)) return true;
+		if (["n", "no"].includes(ans)) return false;
+		warn("Please answer y or n.");
+	}
+}
+
+async function multiFallback(ctx, message, options) {
+	title(message);
+	info("Answer y/n for each.");
+	const picked = [];
+	for (const opt of options) {
+		const on = await confirmFallback(ctx, opt.label, opt.selected !== false);
+		if (on) picked.push(opt.value);
+	}
+	return picked;
+}

--- a/scripts/setup/setup.test.mjs
+++ b/scripts/setup/setup.test.mjs
@@ -11,6 +11,7 @@ import {
 	removeNavLink,
 	removeRobotsLink,
 	stripShopifyConfig,
+	stripThreeConfig,
 	sweepUnusedImports,
 } from "./apply.mjs";
 
@@ -106,6 +107,30 @@ describe("buildPlan", () => {
 		assert.ok(deletes.includes("packages/three"));
 		assert.ok(!deletes.includes("apps/astro/src/pages/_/content.astro"));
 	});
+
+	it("Solid without CMS still strips leftover SEO tags", () => {
+		const plan = buildPlan(ROOT, {
+			framework: "solid",
+			cms: "none",
+			webgl: "none",
+			extras: ["optimise"],
+			runInstall: false,
+		});
+		assert.ok(
+			plan.ops.some(
+				(op) =>
+					op.type === "patch-file" &&
+					op.path === "apps/solid/src/routes/_/animation/(animation).tsx",
+			),
+		);
+		assert.ok(
+			plan.ops.some(
+				(op) =>
+					op.type === "delete" &&
+					String(op.path).includes("app.config.timestamp_"),
+			),
+		);
+	});
 });
 
 describe("source patches", () => {
@@ -152,16 +177,36 @@ export default function Home() {
 	});
 
 	it("removes nav link objects", () => {
-		const src = `const NAV_LINKS = [
+		const compact = `const NAV_LINKS = [
   { to: "/_/about", text: "About Us" },
   { to: "/_/webgl", text: "WebGl" },
   { to: "/_/shop", text: "Shop" },
 ];
 `;
-		const next = removeNavLink(src, "/_/webgl");
-		assert.equal(next.includes("/_/webgl"), false);
-		assert.equal(next.includes("/_/about"), true);
-		assert.equal(next.includes("/_/shop"), true);
+		const compactNext = removeNavLink(compact, "/_/webgl");
+		assert.equal(compactNext.includes("/_/webgl"), false);
+		assert.equal(compactNext.includes("/_/about"), true);
+		assert.equal(compactNext.includes("/_/shop"), true);
+
+		const multiline = `const NAV_LINKS = [
+  {
+    href: "/_/about",
+    text: "About Us",
+  },
+  {
+    href: "/_/webgl",
+    text: "WebGl",
+  },
+  {
+    href: "/_/content",
+    text: "CMS Content",
+  },
+];
+`;
+		const multiNext = removeNavLink(removeNavLink(multiline, "/_/webgl"), "/_/content");
+		assert.equal(multiNext.includes("/_/webgl"), false);
+		assert.equal(multiNext.includes("/_/content"), false);
+		assert.equal(multiNext.includes("/_/about"), true);
 	});
 
 	it("clears transpilePackages and shopify route rules", () => {
@@ -194,6 +239,25 @@ export default function Home() {
 		assert.equal(next.includes("/_/shop"), false);
 		assert.equal(next.includes("shopify"), false);
 		assert.equal(next.includes("crawlLinks: true"), true);
+	});
+
+	it("strips unquoted solid/optimizeDeps three config", () => {
+		const src = `export default defineConfig({
+	// \`three\` is a large, plain-JS library
+	solid: {
+		exclude: [/[\\\\/]three@/],
+	},
+	vite: {
+		optimizeDeps: {
+			exclude: ["three"],
+		},
+	},
+});
+`;
+		const next = stripThreeConfig(src);
+		assert.equal(next.includes("solid:"), false);
+		assert.equal(next.includes("optimizeDeps"), false);
+		assert.equal(next.includes("vite:"), true);
 	});
 
 	it("removes the robots Link", () => {

--- a/scripts/setup/setup.test.mjs
+++ b/scripts/setup/setup.test.mjs
@@ -1,0 +1,212 @@
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildPlan, defaultAnswers, parseArgs } from "./model.mjs";
+import {
+	emptyTranspilePackages,
+	removeConstDecl,
+	removeJsxTag,
+	removeNavLink,
+	removeRobotsLink,
+	stripShopifyConfig,
+	sweepUnusedImports,
+} from "./apply.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function paths(plan, type) {
+	return plan.ops.filter((op) => op.type === type).map((op) => op.path);
+}
+
+describe("parseArgs", () => {
+	it("reads flags", () => {
+		assert.deepEqual(parseArgs(["--yes", "--dry-run"]), {
+			dryRun: true,
+			yes: true,
+			help: false,
+		});
+	});
+});
+
+describe("buildPlan", () => {
+	it("default Solid keeps the full stack", () => {
+		const plan = buildPlan(ROOT, defaultAnswers());
+		assert.deepEqual(plan.keep, [
+			"apps/cms",
+			"apps/solid",
+			"packages/config",
+			"packages/gl-context",
+			"packages/modules",
+			"packages/router",
+			"packages/sanity",
+			"packages/seo",
+			"packages/shopify",
+			"packages/tailwind",
+			"packages/three",
+			"scripts/optimise",
+			"scripts/sanity-yaml",
+			"scripts/sync-sanity",
+		]);
+		assert.ok(paths(plan, "delete").includes("apps/next"));
+		assert.ok(paths(plan, "delete").includes("apps/astro"));
+		assert.ok(!paths(plan, "delete").includes("apps/solid"));
+		assert.ok(!paths(plan, "delete").includes("packages/three"));
+	});
+
+	it("Next + no CMS + no WebGL deletes unused stack and feature files", () => {
+		const plan = buildPlan(ROOT, {
+			framework: "next",
+			cms: "none",
+			webgl: "none",
+			extras: ["optimise"],
+			runInstall: false,
+		});
+		const deletes = paths(plan, "delete");
+		for (const path of [
+			"apps/solid",
+			"apps/astro",
+			"apps/cms",
+			"packages/router",
+			"packages/sanity",
+			"packages/seo",
+			"packages/shopify",
+			"packages/three",
+			"packages/gl-context",
+			"apps/next/app/%5F/webgl",
+			"apps/next/app/%5F/content",
+			"apps/next/components/WebglCanvas.tsx",
+		]) {
+			assert.ok(deletes.includes(path), `expected delete ${path}`);
+		}
+		assert.ok(paths(plan, "write-file").includes("apps/next/app/page.tsx"));
+		assert.ok(
+			plan.ops.some((op) => op.type === "remove-nav-link" && op.href === "/_/webgl"),
+		);
+		assert.ok(
+			plan.ops.some((op) => op.type === "remove-nav-link" && op.href === "/_/content"),
+		);
+	});
+
+	it("Astro + Sanity + no WebGL keeps cms and strips other frameworks", () => {
+		const plan = buildPlan(ROOT, {
+			framework: "astro",
+			cms: "sanity",
+			webgl: "none",
+			extras: [],
+			runInstall: false,
+		});
+		assert.ok(plan.keep.includes("apps/astro"));
+		assert.ok(plan.keep.includes("apps/cms"));
+		assert.ok(plan.keep.includes("packages/sanity"));
+		const deletes = paths(plan, "delete");
+		assert.ok(deletes.includes("apps/solid"));
+		assert.ok(deletes.includes("apps/next"));
+		assert.ok(deletes.includes("packages/three"));
+		assert.ok(!deletes.includes("apps/astro/src/pages/_/content.astro"));
+	});
+});
+
+describe("source patches", () => {
+	it("removes a multiline const and its JSX", () => {
+		const src = `import { clientOnly } from "@solidjs/start";
+import { Gui } from "~/lib/utils/gui";
+import { Scroll } from "~/lib/utils/scroll";
+
+const ClientCanvas = clientOnly(() =>
+  import("@local/three/solid").then((m) => ({ default: m.Canvas })),
+);
+
+export function App() {
+  return (
+    <div>
+      <Scroll />
+      <ClientCanvas
+        deps={{
+          Gui,
+        }}
+      />
+    </div>
+  );
+}
+`;
+		const next = sweepUnusedImports(removeJsxTag(removeConstDecl(src, "ClientCanvas"), "ClientCanvas"));
+		assert.equal(next.includes("ClientCanvas"), false);
+		assert.equal(next.includes("@local/three"), false);
+		assert.equal(next.includes("Gui"), false);
+		assert.equal(next.includes("clientOnly"), false);
+		assert.equal(next.includes("Scroll"), true);
+	});
+
+	it("removes SanityMeta even when props contain >", () => {
+		const src = `import { SanityMeta } from "@local/seo";
+const data = () => ({});
+export default function Home() {
+  return <SanityMeta isHomepage={true} pageData={data()} />;
+}
+`;
+		const next = sweepUnusedImports(removeJsxTag(src, "SanityMeta"));
+		assert.equal(next.includes("SanityMeta"), false);
+		assert.equal(next.includes("@local/seo"), false);
+	});
+
+	it("removes nav link objects", () => {
+		const src = `const NAV_LINKS = [
+  { to: "/_/about", text: "About Us" },
+  { to: "/_/webgl", text: "WebGl" },
+  { to: "/_/shop", text: "Shop" },
+];
+`;
+		const next = removeNavLink(src, "/_/webgl");
+		assert.equal(next.includes("/_/webgl"), false);
+		assert.equal(next.includes("/_/about"), true);
+		assert.equal(next.includes("/_/shop"), true);
+	});
+
+	it("clears transpilePackages and shopify route rules", () => {
+		const cfg = `const nextConfig = {
+  transpilePackages: ["@local/three", "@local/gl-context"],
+};
+`;
+		assert.equal(emptyTranspilePackages(cfg).includes("@local/three"), false);
+
+		const app = `export default defineConfig({
+	server: {
+		prerender: {
+			crawlLinks: true,
+			ignore: ["/_/shop", "/_/shop/**"],
+		},
+		routeRules: {
+			"/_/shop": {
+				isr: { expiration: 60, allowQuery: ["collection", "sort", "after"] },
+				headers: { "cache-control": "public, max-age=0, must-revalidate" },
+			},
+			"/_/shop/**": {
+				isr: { expiration: 60 },
+			},
+			"/api/shopify/revalidate": { isr: false },
+		},
+	},
+});
+`;
+		const next = stripShopifyConfig(app);
+		assert.equal(next.includes("/_/shop"), false);
+		assert.equal(next.includes("shopify"), false);
+		assert.equal(next.includes("crawlLinks: true"), true);
+	});
+
+	it("removes the robots Link", () => {
+		const src = `        <MetaProvider>
+          <Link
+            rel="robots"
+            type="text/plain"
+            href="/api/robots.txt"
+          />
+
+          <Nav />
+`;
+		assert.equal(removeRobotsLink(src).includes("robots"), false);
+		assert.equal(removeRobotsLink(src).includes("<Nav />"), true);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Turns `pnpm setup` (still aliased as `pnpm scaffold`) into a real starter wizard:

- **Arrow-key selects** for framework (Solid / Next / Astro), CMS (Sanity / none), and WebGL (three.js / none; OGL only if that package exists)
- **Space-toggle extras** for SEO (Solid + Sanity), Shopify (Solid), and the image/font optimise script
- Numbered / y-n fallback when stdin is not a TTY
- `--yes` defaults and `--dry-run` preview

Zero dependencies, so it still runs before `pnpm install`.

## Cleanup

The old script only deleted unused workspace directories and printed dangling-import warnings. This one also:

- Deletes feature files (webgl routes/canvas, CMS content + slices, shop, preview/robots APIs, generated Solid config timestamps)
- Rewrites kept source (nav links, static home pages, canvas wiring, `clientRectGl`, Shopify route rules, SanityMeta)
- Prunes workspace deps, leftover `three`, and unused root scripts
- Writes `.starter.json`

`packages/config`, `packages/tailwind`, and `packages/modules` stay as the shared core.

## How to try

```bash
pnpm setup --dry-run
pnpm setup
```

## Verification

- `node --test scripts/setup/setup.test.mjs` (plan + source-patch fixtures)
- `--yes --dry-run` and piped numbered fallback
- Full apply on temp copies: Next/no-CMS/no-WebGL, Solid/no-CMS/no-WebGL, Astro+Sanity/no-WebGL — no dangling `@local/*` imports in kept apps

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7838989-8437-4e5b-8b44-aa3fe3324092?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7838989-8437-4e5b-8b44-aa3fe3324092&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

